### PR TITLE
Fixing a typo in HardwareSerial.cpp

### DIFF
--- a/cores/arduino/HardwareSerial.cpp
+++ b/cores/arduino/HardwareSerial.cpp
@@ -101,7 +101,7 @@ int wiring_stderr_write(const char *data, int nbytes) {
         return Serial.write((const uint8_t*)data, nbytes);
     }
 
-    retirn 0;
+    return 0;
 }
 
 }


### PR DESCRIPTION
one return was called retirn and gave a compile error